### PR TITLE
Issue 72 - default model cdr3 anchors fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build: test clean
 ##			ImmunoProbs and finally builds a docker image of all executables.
 ##
 build-docker: test clean build
-	docker build -t penuts7644/immuno-probs:0.1.13 . && docker tag penuts7644/immuno-probs:0.1.13 penuts7644/immuno-probs:latest
+	docker build -t penuts7644/immuno-probs:0.1.14 . && docker tag penuts7644/immuno-probs:0.1.14 penuts7644/immuno-probs:latest
 
 ##		make test-deploy
 ##			Tests, cleans, builds and uploads all distribution files to PyPI test server.

--- a/galaxy/build_igor_model.xml
+++ b/galaxy/build_igor_model.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="immuno_probs_build_igor_model" name="Build IGoR model" version="0.1.13">
+<tool id="immuno_probs_build_igor_model" name="Build IGoR model" version="0.1.14">
     <requirements>
         <container type="docker">penuts7644/immuno-probs</container>
     </requirements>

--- a/galaxy/evaluate_seqs.xml
+++ b/galaxy/evaluate_seqs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="immuno_probs_evaulate_seqs" name="Evaluate sequences" version="0.1.13">
+<tool id="immuno_probs_evaulate_seqs" name="Evaluate sequences" version="0.1.14">
     <requirements>
         <container type="docker">penuts7644/immuno-probs</container>
     </requirements>

--- a/galaxy/generate_seqs.xml
+++ b/galaxy/generate_seqs.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="immuno_probs_generate_seqs" name="Generate sequences" version="0.1.13">
+<tool id="immuno_probs_generate_seqs" name="Generate sequences" version="0.1.14">
     <requirements>
         <container type="docker">penuts7644/immuno-probs</container>
     </requirements>

--- a/galaxy/locate_cdr3_anchors.xml
+++ b/galaxy/locate_cdr3_anchors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="immuno_probs_locate_cdr3_anchors" name="Locate CDR3 anchors" version="0.1.13">
+<tool id="immuno_probs_locate_cdr3_anchors" name="Locate CDR3 anchors" version="0.1.14">
     <requirements>
         <container type="docker">penuts7644/immuno-probs</container>
     </requirements>

--- a/immuno_probs/cli/build_igor_model.py
+++ b/immuno_probs/cli/build_igor_model.py
@@ -23,7 +23,7 @@ import sys
 
 from immuno_probs.model.default_models import get_default_model_file_paths
 from immuno_probs.model.igor_interface import IgorInterface
-from immuno_probs.util.cli import dynamic_cli_options
+from immuno_probs.util.cli import dynamic_cli_options, make_colored
 from immuno_probs.util.constant import get_config_data
 from immuno_probs.util.io import preprocess_separated_file, preprocess_reference_file, \
 is_fasta, is_separated, copy_to_dir
@@ -168,10 +168,10 @@ class BuildIgorModel(object):
                 )
                 ref_list.append([i[0], filename])
             command_list.append(ref_list)
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
         except IOError as err:
-            sys.stdout.write('\033[91merror\033[0m\n')
-            sys.stderr.write(str(err) + '\n')
+            sys.stdout.write(make_colored('error\n', 'red'))
+            sys.stderr.write(make_colored(str(err) + '\n', 'bg-red'))
             return
 
         # Set the initial model parameters using a build-in model.
@@ -186,7 +186,7 @@ class BuildIgorModel(object):
                 'set_custom_model',
                 get_default_model_file_paths(name='human-t-alpha')['parameters']
             ])
-        sys.stdout.write('\033[92msuccess\033[0m\n')
+        sys.stdout.write(make_colored('success\n', 'green'))
 
         # Add the sequence command after pre-processing of the input file.
         sys.stdout.write('Pre-processing input sequence file...')
@@ -210,19 +210,21 @@ class BuildIgorModel(object):
                     )
                     command_list.append(['read_seqs', input_seqs])
                 except KeyError as err:
-                    sys.stdout.write('\033[91merror\033[0m\n')
-                    sys.stderr.write("Given input sequence file does not have " \
-                        "a '{}' column\n".format(get_config_data('NT_COL')))
+                    sys.stdout.write(make_colored('error\n', 'red'))
+                    sys.stderr.write(make_colored(
+                        "Given input sequence file does not have a '{}' column\n" \
+                        .format(get_config_data('NT_COL')), 'bg-red'))
                     return
             else:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write('Given input sequence file could not be ' \
-                    'detected as FASTA file or separated data type\n')
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(
+                    'Given input sequence file could not be detected as FASTA ' \
+                    'file or separated data type\n', 'bg-red'))
                 return
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
         except IOError as err:
-            sys.stdout.write('\033[91merror\033[0m\n')
-            sys.stderr.write(str(err) + '\n')
+            sys.stdout.write(make_colored('error\n', 'red'))
+            sys.stderr.write(make_colored(str(err) + '\n', 'bg-red'))
             return
 
         # Add alignment commands.
@@ -236,11 +238,12 @@ class BuildIgorModel(object):
         igor_cline = IgorInterface(args=command_list)
         exit_code, _, stderr, _ = igor_cline.call()
         if exit_code != 0:
-            sys.stdout.write('\033[91merror\033[0m\n')
-            sys.stderr.write("An error occurred during execution of IGoR " \
-                "command (exit code {}):\n{}\n".format(exit_code, stderr))
+            sys.stdout.write(make_colored('error\n', 'red'))
+            sys.stderr.write(make_colored(
+                "An error occurred during execution of IGoR command (exit " \
+                "code {}):\n{}\n".format(exit_code, stderr), 'bg-red'))
             return
-        sys.stdout.write('\033[92msuccess\033[0m\n')
+        sys.stdout.write(make_colored('success\n', 'green'))
 
         # Copy the output files to the output directory with prefix.
         sys.stdout.write('Writting files...')
@@ -256,7 +259,7 @@ class BuildIgorModel(object):
             filename='{}_params'.format(output_prefix),
             directory=output_dir)
         sys.stdout.write("(written '{}' and '{}')...".format(filename_1, filename_2))
-        sys.stdout.write('\033[92msuccess\033[0m\n')
+        sys.stdout.write(make_colored('success\n', 'green'))
 
 
 def main():

--- a/immuno_probs/cli/evaluate_seqs.py
+++ b/immuno_probs/cli/evaluate_seqs.py
@@ -327,16 +327,18 @@ class EvaluateSeqs(object):
                                    ['J', files['j_anchors']]]
                     if args.model == 'tutorial-model':
                         args.seqs = files['cdr3']
+                    separator = '\t'
                 elif args.custom_model:
                     model_type = args.type
                     model = IgorLoader(model_type=model_type,
                                        model_params=args.custom_model[0],
                                        model_marginals=args.custom_model[1])
+                    separator = get_config_data('SEPARATOR')
                 for gene in args.anchor:
                     anchor_file = preprocess_separated_file(
                         os.path.join(working_dir, 'cdr3_anchors'),
                         str(gene[1]),
-                        get_config_data('SEPARATOR'),
+                        separator,
                         ','
                     )
                     model.set_anchor(gene=gene[0], file=anchor_file)

--- a/immuno_probs/cli/evaluate_seqs.py
+++ b/immuno_probs/cli/evaluate_seqs.py
@@ -28,7 +28,7 @@ from immuno_probs.cdr3.olga_container import OlgaContainer
 from immuno_probs.model.default_models import get_default_model_file_paths
 from immuno_probs.model.igor_interface import IgorInterface
 from immuno_probs.model.igor_loader import IgorLoader
-from immuno_probs.util.cli import dynamic_cli_options
+from immuno_probs.util.cli import dynamic_cli_options, make_colored
 from immuno_probs.util.conversion import nucleotides_to_aminoacids
 from immuno_probs.util.constant import get_config_data
 from immuno_probs.util.exception import ModelLoaderException, GeneIdentifierException, OlgaException
@@ -196,7 +196,7 @@ class EvaluateSeqs(object):
                     )
                     ref_list.append([i[0], filename])
                 command_list.append(ref_list)
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
             # Add the sequence command after pre-processing of the input file.
             sys.stdout.write('Pre-processing input sequence file...')
@@ -220,19 +220,21 @@ class EvaluateSeqs(object):
                         )
                         command_list.append(['read_seqs', input_seqs])
                     except KeyError as err:
-                        sys.stdout.write('\033[91merror\033[0m\n')
-                        sys.stderr.write("Given input sequence file does not" \
-                            "have a '{}' column\n".format(get_config_data('NT_COL')))
+                        sys.stdout.write(make_colored('error\n', 'red'))
+                        sys.stderr.write(make_colored(
+                            "Given input sequence file does not have a '{}' " \
+                            "column\n".format(get_config_data('NT_COL')), 'bg-red'))
                         return
                 else:
-                    sys.stdout.write('\033[91merror\033[0m\n')
-                    sys.stderr.write('Given input sequence file could not be ' \
-                        'detected as FASTA file or separated data type\n')
+                    sys.stdout.write(make_colored('error\n', 'red'))
+                    sys.stderr.write(make_colored(
+                        'Given input sequence file could not be detected as ' \
+                        'FASTA file or separated data type\n', 'bg-red'))
                     return
-                sys.stdout.write('\033[92msuccess\033[0m\n')
+                sys.stdout.write(make_colored('success\n', 'green'))
             except IOError as err:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write(str(err) + '\n')
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(str(err) + '\n', 'bg-red'))
                 return
 
             # Add alignment commands.
@@ -247,11 +249,12 @@ class EvaluateSeqs(object):
             igor_cline = IgorInterface(args=command_list)
             exit_code, _, stderr, _ = igor_cline.call()
             if exit_code != 0:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write("An error occurred during execution of IGoR " \
-                    "command (exit code {}):\n{}\n".format(exit_code, stderr))
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(
+                    "An error occurred during execution of IGoR command (exit " \
+                    "code {}):\n{}\n".format(exit_code, stderr), 'bg-red'))
                 return
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
             # Read in all data frame files, based on input file type.
             sys.stdout.write('Processing generation probabilities...')
@@ -272,8 +275,8 @@ class EvaluateSeqs(object):
                                     inplace=True)
                 full_pgen_df.loc[:, get_config_data('AA_P_COL')] = numpy.nan
             except IOError as err:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write(str(err) + '\n')
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(str(err) + '\n', 'bg-red'))
                 return
 
             # Insert amino acid sequence column if not existent.
@@ -287,7 +290,7 @@ class EvaluateSeqs(object):
 
             # Merge IGoR generated sequence output dataframes.
             full_pgen_df = seqs_df.merge(full_pgen_df, left_index=True, right_index=True)
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
             # Write the pandas dataframe to a separated file.
             sys.stdout.write('Writting file...')
@@ -301,7 +304,7 @@ class EvaluateSeqs(object):
                 separator=get_config_data('SEPARATOR'),
                 index_name=get_config_data('I_COL'))
             sys.stdout.write("(written '{}')...".format(filename))
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
         # If the given type of sequences evaluation is CDR3, use OLGA.
         elif args.cdr3:
@@ -338,10 +341,10 @@ class EvaluateSeqs(object):
                     )
                     model.set_anchor(gene=gene[0], file=anchor_file)
                 model.initialize_model()
-                sys.stdout.write('\033[92msuccess\033[0m\n')
+                sys.stdout.write(make_colored('success\n', 'green'))
             except (ModelLoaderException, GeneIdentifierException) as err:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write(str(err) + '\n')
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(str(err) + '\n', 'bg-red'))
                 return
 
             # Based on input file type, load in input file.
@@ -357,14 +360,15 @@ class EvaluateSeqs(object):
                         file=args.seqs, separator=get_config_data('SEPARATOR'),
                         index_col=get_config_data('I_COL'))
                 else:
-                    sys.stdout.write('\033[91merror\033[0m\n')
-                    sys.stderr.write('Given input sequence file could not be ' \
-                        'detected as FASTA file or separated data type\n')
+                    sys.stdout.write(make_colored('error\n', 'red'))
+                    sys.stderr.write(make_colored(
+                        'Given input sequence file could not be detected as ' \
+                        'FASTA file or separated data type\n', 'bg-red'))
                     return
-                sys.stdout.write('\033[92msuccess\033[0m\n')
+                sys.stdout.write(make_colored('success\n', 'green'))
             except (IOError) as err:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write(str(err) + '\n')
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(str(err) + '\n', 'bg-red'))
                 return
 
             # Evaluate the sequences.
@@ -379,10 +383,10 @@ class EvaluateSeqs(object):
 
                 # Merge IGoR generated sequence output dataframes.
                 cdr3_pgen_df = seqs_df.merge(cdr3_pgen_df, left_index=True, right_index=True)
-                sys.stdout.write('\033[92msuccess\033[0m\n')
+                sys.stdout.write(make_colored('success\n', 'green'))
             except (OlgaException) as err:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write(str(err) + '\n')
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(str(err) + '\n', 'bg-red'))
                 return
 
             # Write the pandas dataframe to a separated file.
@@ -397,7 +401,7 @@ class EvaluateSeqs(object):
                 separator=get_config_data('SEPARATOR'),
                 index_name=get_config_data('I_COL'))
             sys.stdout.write("(written '{}')...".format(filename))
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
 
 def main():

--- a/immuno_probs/cli/generate_seqs.py
+++ b/immuno_probs/cli/generate_seqs.py
@@ -288,16 +288,18 @@ class GenerateSeqs(object):
                                        model_marginals=files['marginals'])
                     args.anchor = [['V', files['v_anchors']],
                                    ['J', files['j_anchors']]]
+                    separator = '\t'
                 elif args.custom_model:
                     model_type = args.type
                     model = IgorLoader(model_type=model_type,
                                        model_params=args.custom_model[0],
                                        model_marginals=args.custom_model[1])
+                    separator = get_config_data('SEPARATOR')
                 for gene in args.anchor:
                     anchor_file = preprocess_separated_file(
                         os.path.join(working_dir, 'cdr3_anchors'),
                         str(gene[1]),
-                        get_config_data('SEPARATOR'),
+                        separator,
                         ','
                     )
                     model.set_anchor(gene=gene[0], file=anchor_file)

--- a/immuno_probs/cli/generate_seqs.py
+++ b/immuno_probs/cli/generate_seqs.py
@@ -27,7 +27,7 @@ from immuno_probs.cdr3.olga_container import OlgaContainer
 from immuno_probs.model.default_models import get_default_model_file_paths
 from immuno_probs.model.igor_interface import IgorInterface
 from immuno_probs.model.igor_loader import IgorLoader
-from immuno_probs.util.cli import dynamic_cli_options
+from immuno_probs.util.cli import dynamic_cli_options, make_colored
 from immuno_probs.util.conversion import nucleotides_to_aminoacids
 from immuno_probs.util.constant import get_config_data
 from immuno_probs.util.exception import ModelLoaderException, GeneIdentifierException, OlgaException
@@ -212,7 +212,7 @@ class GenerateSeqs(object):
                     copy_to_dir(working_dir, str(args.custom_model[0]), 'txt'),
                     copy_to_dir(working_dir, str(args.custom_model[1]), 'txt')
                 ])
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
             # Add generate command.
             command_list.append(['generate', str(args.generate), ['noerr']])
@@ -222,11 +222,12 @@ class GenerateSeqs(object):
             igor_cline = IgorInterface(args=command_list)
             exit_code, _, stderr, _ = igor_cline.call()
             if exit_code != 0:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write("An error occurred during execution of IGoR " \
-                    "command (exit code {}):\n{}\n".format(exit_code, stderr))
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(
+                    "An error occurred during execution of IGoR command (exit " \
+                    "code {}):\n{}\n".format(exit_code, stderr), 'bg-red'))
                 return
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
             # Merge the generated output files together (translated).
             sys.stdout.write('Processing sequence realizations...')
@@ -254,7 +255,7 @@ class GenerateSeqs(object):
             realizations_df = self._process_realizations(data=realizations_df,
                                                          model=model)
             full_seqs_df = sequence_df.merge(realizations_df, left_index=True, right_index=True)
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
             # Write the pandas dataframe to a separated file.
             sys.stdout.write('Writting file...')
@@ -268,7 +269,7 @@ class GenerateSeqs(object):
                 separator=get_config_data('SEPARATOR'),
                 index_name=get_config_data('I_COL'))
             sys.stdout.write("(written '{}')...".format(filename))
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
         # If the given type of sequences generation is CDR3, use OLGA.
         elif args.cdr3:
@@ -301,10 +302,10 @@ class GenerateSeqs(object):
                     )
                     model.set_anchor(gene=gene[0], file=anchor_file)
                 model.initialize_model()
-                sys.stdout.write('\033[92msuccess\033[0m\n')
+                sys.stdout.write(make_colored('success\n', 'green'))
             except (ModelLoaderException, GeneIdentifierException) as err:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write(str(err) + '\n')
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(str(err) + '\n', 'bg-red'))
                 return
 
             # Setup the sequence generator and generate sequences.
@@ -312,10 +313,10 @@ class GenerateSeqs(object):
             try:
                 seq_generator = OlgaContainer(igor_model=model)
                 cdr3_seqs_df = seq_generator.generate(num_seqs=args.generate)
-                sys.stdout.write('\033[92msuccess\033[0m\n')
+                sys.stdout.write(make_colored('success\n', 'green'))
             except OlgaException as err:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write(str(err) + '\n')
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(str(err) + '\n', 'bg-red'))
                 return
 
             # Write the pandas dataframe to a separated file with.
@@ -330,7 +331,7 @@ class GenerateSeqs(object):
                 separator=get_config_data('SEPARATOR'),
                 index_name=get_config_data('I_COL'))
             sys.stdout.write("(written '{}')...".format(filename))
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
 
 def main():

--- a/immuno_probs/cli/locate_cdr3_anchors.py
+++ b/immuno_probs/cli/locate_cdr3_anchors.py
@@ -25,7 +25,7 @@ import numpy
 
 from immuno_probs.alignment.muscle_aligner import MuscleAligner
 from immuno_probs.cdr3.anchor_locator import AnchorLocator
-from immuno_probs.util.cli import dynamic_cli_options
+from immuno_probs.util.cli import dynamic_cli_options, make_colored
 from immuno_probs.util.constant import get_config_data
 from immuno_probs.util.exception import AlignerException, GeneIdentifierException
 from immuno_probs.util.io import copy_to_dir, preprocess_reference_file, \
@@ -119,8 +119,8 @@ class LocateCdr3Anchors(object):
                 locator = AnchorLocator(alignment=aligner.get_muscle_alignment(),
                                         gene=gene[0])
             except (AlignerException, GeneIdentifierException) as err:
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write(str(err) + '\n')
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(str(err) + '\n', 'bg-red'))
                 return
 
             if args.motif is not None:
@@ -135,10 +135,11 @@ class LocateCdr3Anchors(object):
                 anchors_df['gene'], anchors_df['function'] = zip(*anchors_df['gene'].apply(
                     lambda value: (value.split('|')[1], value.split('|')[3])))
             except (IndexError, ValueError):
-                sys.stdout.write('\033[91merror\033[0m\n')
-                sys.stderr.write("FASTA header needs to be separated by '|', " \
-                    "needs to have gene name on index position 1 and function " \
-                    "on index position 3: '{}'\n".format(anchors_df['gene']))
+                sys.stdout.write(make_colored('error\n', 'red'))
+                sys.stderr.write(make_colored(
+                    "FASTA header needs to be separated by '|', needs to have " \
+                    "gene name on index position 1 and function on index " \
+                    "position 3: '{}'\n".format(anchors_df['gene']), 'bg-red'))
                 return
 
             # Apply some filtering to the anchor dataframe.
@@ -155,7 +156,7 @@ class LocateCdr3Anchors(object):
                 directory=output_dir,
                 separator=get_config_data('SEPARATOR'))
             sys.stdout.write("(written '{}' for {} gene)...".format(filename, gene[0]))
-            sys.stdout.write('\033[92msuccess\033[0m\n')
+            sys.stdout.write(make_colored('success\n', 'green'))
 
 
 def main():

--- a/immuno_probs/util/cli.py
+++ b/immuno_probs/util/cli.py
@@ -50,3 +50,41 @@ def dynamic_cli_options(parser, options):
 
     # Return the updated parser.
     return parser
+
+def make_colored(text, color):
+    """Turn a text string into a colored representation.
+
+    Parameters
+    ----------
+    text : str
+        A text string to modify.
+    color : str
+        One of the predefined color options to use for transforming the input
+        string value.
+
+    Returns
+    -------
+    str
+        With the new colored values attached.
+
+    Notes
+    -----
+        As of now, you can select one of the following: black, red, green,
+        white, bg-black, bg-red, bg-green and bg-white.
+
+    """
+    # Specify the colors in the dict.
+    colors = {
+        'black': '\033[30m',
+        'red': '\033[31m',
+        'green': '\033[32m',
+        'white': '\033[37m',
+        'bg-black': '\033[0;37;40m',
+        'bg-red': '\033[0;37;41m',
+        'bg-green': '\033[0;30;42m',
+        'bg-white': '\033[0;30;47m',
+    }
+
+    # Create new text string and return.
+    new_text = colors[color] + text + '\033[0m'
+    return new_text

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # Include the license file in the wheel.
 [metadata]
 name = immuno-probs
-version = 0.1.13
+version = 0.1.14
 url = https://github.com/penuts7644/ImmunoProbs
 author = Wout van Helvoirt
 author_email = wout.van.helvoirt@icloud.com


### PR DESCRIPTION
fixes #72 

In this PR:
- Updated the color code terminal messages to be more distinctive between `stdout` and `stderr`.
- Fixed the index issue for the CDR3 anchors for build-in models.
- Version bump to 0.1.14