### PR TITLE
Issue 88 - Tool renaming and flag simplification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test:
 ##			Removes the old distribution directories and files.
 ##
 clean:
-	rm -rf ./dist && rm -rf ./build && rm -rf ./docs/_build && rm -rf ./.pytest_cache && rm -rf ./immuno_probs.egg-info && find . -name '*.pyc' -type f -delete
+	rm -rf ./dist && rm -rf ./build && rm -rf ./docs/_build && rm -rf ./.pytest_cache && find . -name '*.pyc' -type f -delete
 
 ##		make build
 ##			Perfoms tests, a dir clean, builds the new distribution package as

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,13 +29,13 @@ Requirements
 
 All Python dependencies that are used by this package are installed through pip upon installation of ImmunoProbs. However, some software (not available via pip) needs to installed manually when planning on using certain commandline tools from ImmunoProbs:
 
-+------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Command                                                    | Requirement                                                                                                                                                                                                                                                                                                               |
-+============================================================+===========================================================================================================================================================================================================================================================================================================================+
-| ``locate-cdr3-anchors``                                    | This requires `MUSCLE <http://www.drive5.com/muscle/>`__ to be installed. For linux, MUSCLE can be installed via ``apt-get install muscle``. For macOS with HomeBrew, tap into ``brewsci/bio`` and install MUSCLE via ``brew install muscle``                                                                             |
-+------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| ``build-igor-model`` ``generate_seqs`` ``evaluate_seqs``   | This will use Python's subprocess package to pass the user arguments to `IGoR <https://github.com/qmarcou/IGoR>`__. For these tools to work properly, make sure that you have at least compiled and installed IGoR version 1.3.0 using the guide in `IGoR's documentation <https://qmarcou.github.io/IGoR/#install>`__.   |
-+------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Command                                       | Requirement                                                                                                                                                                                                                                                                                                               |
++===============================================+===========================================================================================================================================================================================================================================================================================================================+
+| ``locate``                                    | This requires `MUSCLE <http://www.drive5.com/muscle/>`__ to be installed. For linux, MUSCLE can be installed via ``apt-get install muscle``. For macOS with HomeBrew, tap into ``brewsci/bio`` and install MUSCLE via ``brew install muscle``                                                                             |
++-----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``build`` ``generate`` ``evaluate``           | This will use Python's subprocess package to pass the user arguments to `IGoR <https://github.com/qmarcou/IGoR>`__. For these tools to work properly, make sure that you have at least compiled and installed IGoR version 1.3.0 using the guide in `IGoR's documentation <https://qmarcou.github.io/IGoR/#install>`__.   |
++-----------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 Docker
 ^^^^^^
@@ -74,8 +74,8 @@ The ImmunoProbs docker image can be integrated as a galaxy tool by modifying the
 
     wget -P <LOCATION> "https://raw.githubusercontent.com/penuts7644/ImmunoProbs/master/galaxy/build_igor_model.xml" & \
     wget -P <LOCATION> "https://raw.githubusercontent.com/penuts7644/ImmunoProbs/master/galaxy/locate_cdr3_anchors.xml" & \
-    wget -P <LOCATION> "https://raw.githubusercontent.com/penuts7644/ImmunoProbs/master/galaxy/generate_seqs.xml" & \
-    wget -P <LOCATION> "https://raw.githubusercontent.com/penuts7644/ImmunoProbs/master/galaxy/evaluate_seqs.xml"
+    wget -P <LOCATION> "https://raw.githubusercontent.com/penuts7644/ImmunoProbs/master/galaxy/generate_sequences.xml" & \
+    wget -P <LOCATION> "https://raw.githubusercontent.com/penuts7644/ImmunoProbs/master/galaxy/evaluate_sequences.xml"
 
 Finally, add the section with the ImmunoProbs tools to the ``tool_conf.xml``. Replace ``<LOCATION>`` to the location of each ImmunoProbs tool within you galaxy tools directory.
 
@@ -84,8 +84,8 @@ Finally, add the section with the ImmunoProbs tools to the ``tool_conf.xml``. Re
     <section id="immuno_probs" name="ImmunoProbs">
         <tool file="<LOCATION>/build_igor_model.xml" />
         <tool file="<LOCATION>/locate_cdr3_anchors.xml" />
-        <tool file="<LOCATION>/generate_seqs.xml" />
-        <tool file="<LOCATION>/evaluate_seqs.xml" />
+        <tool file="<LOCATION>/generate_sequences.xml" />
+        <tool file="<LOCATION>/evaluate_sequences.xml" />
     </section>
 
 Make sure to have setup you galaxy server to be able to use docker images. This can be done inside the ``job_conf.xml`` file by adding the following:

--- a/docs/source/immuno_probs.cli.rst
+++ b/docs/source/immuno_probs.cli.rst
@@ -9,18 +9,18 @@ immuno\_probs.cli.build\_igor\_model module
     :undoc-members:
     :show-inheritance:
 
-immuno\_probs.cli.evaluate\_seqs module
+immuno\_probs.cli.evaluate\_sequences module
 ---------------------------------------
 
-.. automodule:: immuno_probs.cli.evaluate_seqs
+.. automodule:: immuno_probs.cli.evaluate_sequences
     :members:
     :undoc-members:
     :show-inheritance:
 
-immuno\_probs.cli.generate\_seqs module
+immuno\_probs.cli.generate\_sequences module
 ---------------------------------------
 
-.. automodule:: immuno_probs.cli.generate_seqs
+.. automodule:: immuno_probs.cli.generate_sequences
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -23,14 +23,14 @@ The included IGoR models can be used to generate and evaluate V(D)J or CDR3 sequ
 Generate V(D)J sequences
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Generating sequences with a predefined IGoR model can be done by specifying the model you would like to use (``-model``) and the number of sequences to generate (``-generate``).
+Generating sequences with a predefined IGoR model can be done by specifying the model you would like to use (``-model``) and the number of sequences to generate (``-n-gen``).
 
 .. code-block:: none
 
     immuno-probs \
-      generate-seqs \
+      generate \
         -model tutorial-model \
-        -generate 100
+        -n-gen 100
 
 Calculate the generation probabilities for V(D)J sequences
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -40,7 +40,7 @@ We can calculate the generation probability of our VDJ sequences by specifying t
 .. code-block:: none
 
     immuno-probs \
-      evaluate-seqs \
+      evaluate \
         -model tutorial-model \
         -seqs VDJ_sequences.tsv
 
@@ -52,9 +52,9 @@ Since the CDR3 sequences generation and evaluation requires additional V and J a
 .. code-block:: none
 
     immuno-probs \
-      generate-seqs \
+      generate \
         -model tutorial-model \
-        -generate 100 \
+        -n-gen 100 \
         -cdr3
 
 Calculate the generation probabilities for CDR3 sequences
@@ -65,7 +65,7 @@ Similar to step **b**, but now we are using CDR3 input sequences so we’ll have
 .. code-block:: none
 
     immuno-probs \
-      evaluate-seqs \
+      evaluate \
         -model tutorial-model \
         -seqs CDR3_sequences.tsv \
         -cdr3
@@ -83,7 +83,7 @@ We'll start by specifying the reference genomic template FASTA files (``-ref``) 
 .. code-block:: none
 
     immuno-probs \
-      build-igor-model \
+      build \
         -ref V /tutorial_data/TRBV.fasta \
         -ref D /tutorial_data/TRBD.fasta \
         -ref J /tutorial_data/TRBJ.fasta \
@@ -99,7 +99,7 @@ CDR3 anchor positions are required in order to accurately generate and evaluate 
 .. code-block:: none
 
     immuno-probs \
-      locate-cdr3-anchors \
+      locate \
         -ref V /tutorial_data/TRBV.fasta \
         -ref J /tutorial_data/TRBJ.fasta
 
@@ -111,9 +111,9 @@ We need to specify our model marginals and parameters files as well as the model
 .. code-block:: none
 
     immuno-probs \
-      generate-seqs \
+      generate \
         -custom-model /tutorial_data/model_params.txt /tutorial_data/model_marginals.txt \
-        -generate 100 \
+        -n-gen 100 \
         -type beta
 
 To generate some CDR3 sequences, we'll add the ``-cdr3`` flag at the end of the command and specify the anchor position files created in section **b** with ``-anchor``.
@@ -121,9 +121,9 @@ To generate some CDR3 sequences, we'll add the ``-cdr3`` flag at the end of the 
 .. code-block:: none
 
     immuno-probs \
-      generate-seqs \
+      generate \
         -custom-model /tutorial_data/model_params.txt /tutorial_data/model_marginals.txt \
-        -generate 100 \
+        -n-gen 100 \
         -type beta \
         -cdr3 \
         -anchor V /tutorial_data/V_gene_CDR3_anchors.tsv \
@@ -137,7 +137,7 @@ We are selecting the sequences generated in the previous step (``-seqs``), the m
 .. code-block:: none
 
     immuno-probs \
-      evaluate-seqs \
+      evaluate \
         -custom-model /tutorial_data/model_params.txt /tutorial_data/model_marginals.txt \
         -seqs /tutorial_data/generated_seqs_beta.tsv \
         -type beta \
@@ -150,7 +150,7 @@ To evaluate CDR3 sequences generated in the previous section, we'll add the ``-c
 .. code-block:: none
 
     immuno-probs \
-      evaluate-seqs \
+      evaluate \
         -custom-model /tutorial_data/model_params.txt /tutorial_data/model_marginals.txt \
         -seqs /tutorial_data/generated_seqs_beta_CDR3.tsv \
         -type beta \

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -205,14 +205,14 @@ Additionally to the general sections, there are sections for each tool (e.g ``LO
     ; Name of the column containing the J gene choice string.
     J_GENE_COL = gene_choice_j
 
-    ; Parameters specific for the 'locate_cdr3_anchors' tool.
-    [LOCATE_CDR3_ANCHORS]
+    ; Parameters specific for the 'locate' tool.
+    [LOCATE]
     ; The default search motifs for the V gene.
     V_MOTIFS = TGT,TGC
     ; The default search motifs for the J gene.
     J_MOTIFS = TGG,TTC,TTT
 
-    ; Parameters specific for the 'evaluate_sequences' tool.
-    [EVALUATE_SEQUENCES]
+    ; Parameters specific for the 'evaluate' tool.
+    [EVALUATE]
     ; The allele value to use when allele information from the input date should not be used.
     ALLELE = 01

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -27,7 +27,7 @@ You can create your own IGoR model by specifying the reference genomic template 
 .. code-block:: none
 
     immuno-probs \
-      build-igor-model \
+      build \
         -ref <GENE> <FASTA> \
         -seqs <SEPARATED/FASTA> \
         -n-iter <NUM ITERATIONS> \
@@ -41,7 +41,7 @@ CDR3 anchor positions are required in order to accurately generate and evaluate 
 .. code-block:: none
 
     immuno-probs \
-      locate-cdr3-anchors \
+      locate \
         -ref <GENE> <FASTA>
         -motif <MOTIF>
 
@@ -50,23 +50,23 @@ Generate VJ, VDJ or CDR3 sequences
 
 Generation of sequences can be done with either an included model (``model``) or by selecting your own model marginals and parameters files (``custom-model``).
 
-Generating sequences with a predefined IGoR model can be done by specifying the model you would like to use in combination with the number of sequences to generate (``generate``).
+Generating sequences with a predefined IGoR model can be done by specifying the model you would like to use in combination with the number of sequences to generate (``n-gen``).
 
 .. code-block:: none
 
     immuno-probs \
-      generate-seqs \
+      generate \
         -model <MODEL NAME> \
-        -generate <NUM SEQUENCES>
+        -n-gen <NUM SEQUENCES>
 
 When using one of your now IGoR models, you'll have to specify the model with parameters and marginals and the type of the input model (``type``).
 
 .. code-block:: none
 
     immuno-probs \
-      generate-seqs \
+      generate \
         -custom-model <PARAMETERS> <MARGINALS> \
-        -generate <NUM SEQUENCES> \
+        -n-gen <NUM SEQUENCES> \
         -type <MODEL TYPE>
 
 Both of the scenarios above will generate VJ or VDJ sequences. If you rather want CDR3 sequences, you'll need to add the ``cdr3`` flag at the end of either of the commands. When using a custom model, you also want to specify the anchor position files created in section **b** by adding: ``anchor <GENE> <SEPARATED>``.
@@ -81,7 +81,7 @@ With the included models, we calculate the generation probability by specifying 
 .. code-block:: none
 
     immuno-probs \
-      evaluate-seqs \
+      evaluate \
         -model <MODEL NAME> \
         -seqs <SEPARATED/FASTA>
 
@@ -90,7 +90,7 @@ With a custom model: select the sequences (``seqs``), the model parameters and m
 .. code-block:: none
 
     immuno-probs \
-      evaluate-seqs \
+      evaluate \
         -custom-model <PARAMETERS> <MARGINALS> \
         -seqs <SEPARATED/FASTA> \
         -ref <GENE> <FASTA> \
@@ -114,45 +114,45 @@ Parameters
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
 |                           | ``config-file``       | An optional configuration file path for ImmunoProbs. This file is combined with the default configuration to make up missing values.                                              |                                                                                          |                                                  |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``build-igor-model``      | ``ref``               | A gene (V, D or J) followed by a reference genome FASTA file. Note: the FASTA reference genome files needs to conform to IGMT annotation (separated by vertical bar character).   |                                                                                          | Yes                                              |
+| ``build``      | ``ref``               | A gene (V, D or J) followed by a reference genome FASTA file. Note: the FASTA reference genome files needs to conform to IGMT annotation (separated by vertical bar character).   |                                                                                          | Yes                                              |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``build-igor-model``      | ``seqs``              | An input FASTA or separated data file with sequences for training the model.                                                                                                      |                                                                                          | Yes                                              |
+| ``build``      | ``seqs``              | An input FASTA or separated data file with sequences for training the model.                                                                                                      |                                                                                          | Yes                                              |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``build-igor-model``      | ``n-iter``            | The number of inference iterations to perform when creating the model.                                                                                                            | 1                                                                                        |                                                  |
+| ``build``      | ``n-iter``            | The number of inference iterations to perform when creating the model.                                                                                                            | 1                                                                                        |                                                  |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``build-igor-model``      | ``type``              | The type of model to create. (select one: ``alpha``, ``beta``, ``light`` or ``heavy``.                                                                                            |                                                                                          | Yes                                              |
+| ``build``      | ``type``              | The type of model to create. (select one: ``alpha``, ``beta``, ``light`` or ``heavy``.                                                                                            |                                                                                          | Yes                                              |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``locate-cdr3-anchors``   | ``ref``               | A gene (V or J) followed by a reference genome FASTA file. Note: the FASTA reference genome files needs to conform to IGMT annotation (separated by vertical bar character).      |                                                                                          | Yes                                              |
+| ``locate``   | ``ref``               | A gene (V or J) followed by a reference genome FASTA file. Note: the FASTA reference genome files needs to conform to IGMT annotation (separated by vertical bar character).      |                                                                                          | Yes                                              |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``locate-cdr3-anchors``   | ``motif``             | The motif to look for. Can be used multiple times.                                                                                                                                | ``V`` (Cystein - TGT and TGC) or ``J`` (Tryptophan - TGG, Phenylalanine - TTC and TTT)   |                                                  |
+| ``locate``   | ``motif``             | The motif to look for. Can be used multiple times.                                                                                                                                | ``V`` (Cystein - TGT and TGC) or ``J`` (Tryptophan - TGG, Phenylalanine - TTC and TTT)   |                                                  |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``generate-seqs``         | ``model``             | Specify a pre-installed model for generation. (select one: ``tutorial-model``, ``human-t-alpha``, ``human-t-beta``, ``human-b-heavy`` or ``mouse-t-beta``).                       |                                                                                          | If ``custom-model`` NOT specified                |
+| ``generate``         | ``model``             | Specify a pre-installed model for generation. (select one: ``tutorial-model``, ``human-t-alpha``, ``human-t-beta``, ``human-b-heavy`` or ``mouse-t-beta``).                       |                                                                                          | If ``custom-model`` NOT specified                |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``generate-seqs``         | ``custom-model``      | A IGoR parameters file followed by an IGoR marginals file.                                                                                                                        |                                                                                          |                                                  |
+| ``generate``         | ``custom-model``      | A IGoR parameters file followed by an IGoR marginals file.                                                                                                                        |                                                                                          |                                                  |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``generate-seqs``         | ``generate``          | The number of sequences to generate.                                                                                                                                              | 1                                                                                        |                                                  |
+| ``generate``         | ``n-gen``             | The number of sequences to generate.                                                                                                                                              | 1                                                                                        |                                                  |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``generate-seqs``         | ``type``              | The type of model to create. (select one: ``alpha``, ``beta``, ``light`` or ``heavy``.                                                                                            |                                                                                          | If ``custom-model`` specified                    |
+| ``generate``         | ``type``              | The type of model to create. (select one: ``alpha``, ``beta``, ``light`` or ``heavy``.                                                                                            |                                                                                          | If ``custom-model`` specified                    |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``generate-seqs``         | ``cdr3``              | Generate CDR3 sequences instead.                                                                                                                                                  | Generate V(D)J full length sequences.                                                    |                                                  |
+| ``generate``         | ``cdr3``              | Generate CDR3 sequences instead.                                                                                                                                                  | Generate V(D)J full length sequences.                                                    |                                                  |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``generate-seqs``         | ``anchor``            | A gene (V or J) followed by a CDR3 anchor separated data file. Note: need to contain gene in the first column, anchor index in the second and gene function in the third.         |                                                                                          | If ``cdr3`` and ``custom-model`` specified       |
+| ``generate``         | ``anchor``            | A gene (V or J) followed by a CDR3 anchor separated data file. Note: need to contain gene in the first column, anchor index in the second and gene function in the third.         |                                                                                          | If ``cdr3`` and ``custom-model`` specified       |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``evaluate-seqs``         | ``model``             | Specify a pre-installed model for generation. (select one: ``tutorial-model``, ``human-t-alpha``, ``human-t-beta``, ``human-b-heavy`` or ``mouse-t-beta``).                       |                                                                                          | If ``custom-model`` NOT specified                |
+| ``evaluate``         | ``model``             | Specify a pre-installed model for generation. (select one: ``tutorial-model``, ``human-t-alpha``, ``human-t-beta``, ``human-b-heavy`` or ``mouse-t-beta``).                       |                                                                                          | If ``custom-model`` NOT specified                |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``evaluate-seqs``         | ``custom-model``      | A IGoR parameters file followed by an IGoR marginals file.                                                                                                                        |                                                                                          |                                                  |
+| ``evaluate``         | ``custom-model``      | A IGoR parameters file followed by an IGoR marginals file.                                                                                                                        |                                                                                          |                                                  |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``evaluate-seqs``         | ``seqs``              | An input FASTA or separated data file with sequences for training the model.                                                                                                      |                                                                                          | Yes                                              |
+| ``evaluate``         | ``seqs``              | An input FASTA or separated data file with sequences for training the model.                                                                                                      |                                                                                          | Yes                                              |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``evaluate-seqs``         | ``ref``               | A gene (V, D or J) followed by a reference genome FASTA file. Note: the FASTA reference genome files needs to conform to IGMT annotation (separated by vertical bar character).   |                                                                                          | If ``custom-model`` without ``cdr3`` specified   |
+| ``evaluate``         | ``ref``               | A gene (V, D or J) followed by a reference genome FASTA file. Note: the FASTA reference genome files needs to conform to IGMT annotation (separated by vertical bar character).   |                                                                                          | If ``custom-model`` without ``cdr3`` specified   |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``evaluate-seqs``         | ``type``              | The type of model to create. (select one: ``alpha``, ``beta``, ``light`` or ``heavy``.                                                                                            |                                                                                          | If ``custom-model`` specified                    |
+| ``evaluate``         | ``type``              | The type of model to create. (select one: ``alpha``, ``beta``, ``light`` or ``heavy``.                                                                                            |                                                                                          | If ``custom-model`` specified                    |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``evaluate-seqs``         | ``cdr3``              | Generate CDR3 sequences instead.                                                                                                                                                  | Generate V(D)J full length sequences.                                                    |                                                  |
+| ``evaluate``         | ``cdr3``              | Generate CDR3 sequences instead.                                                                                                                                                  | Generate V(D)J full length sequences.                                                    |                                                  |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
 | ``evaulate-seqs``         | ``anchor``            | A gene (V or J) followed by a CDR3 anchor separated data file. Note: need to contain gene in the first column, anchor index in the second and gene function in the third.         |                                                                                          | If ``cdr3`` and ``custom-model`` specified       |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
-| ``evaluate-seqs``         | ``use-cdr3-allele``   | If specified in combination with the ``cdr3`` flag, the allele information from the gene choice fields is used to calculate the generation probability.                           | Allele ``*01`` is used for each gene.                                                    |                                                  |
+| ``evaluate``         | ``use-cdr3-allele``   | If specified in combination with the ``cdr3`` flag, the allele information from the gene choice fields is used to calculate the generation probability.                           | Allele ``*01`` is used for each gene.                                                    |                                                  |
 +---------------------------+-----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------+--------------------------------------------------+
 
 Configuration file setup
@@ -212,7 +212,7 @@ Additionally to the general sections, there are sections for each tool (e.g ``LO
     ; The default search motifs for the J gene.
     J_MOTIFS = TGG,TTC,TTT
 
-    ; Parameters specific for the 'evaluate_seqs' tool.
-    [EVALUATE_SEQS]
+    ; Parameters specific for the 'evaluate_sequences' tool.
+    [EVALUATE_SEQUENCES]
     ; The allele value to use when allele information from the input date should not be used.
     ALLELE = 01

--- a/galaxy/build_igor_model.xml
+++ b/galaxy/build_igor_model.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="immuno_probs_build_igor_model" name="Build IGoR model" version="0.1.18">
+<tool id="immuno_probs_build" name="Build IGoR model" version="0.1.18">
     <requirements>
         <container type="docker">penuts7644/immuno-probs</container>
     </requirements>

--- a/galaxy/build_igor_model.xml
+++ b/galaxy/build_igor_model.xml
@@ -13,7 +13,7 @@
             -threads \$GALAXY_SLOTS
 
             ## tool command
-            build-igor-model
+            build
 
                 ## sequence input
                 -seqs '$sequences'

--- a/galaxy/evaluate_sequences.xml
+++ b/galaxy/evaluate_sequences.xml
@@ -13,7 +13,7 @@
             -threads \$GALAXY_SLOTS
 
             ## tool command
-            evaluate-seqs
+            evaluate
 
                 ## specify the model and possibly the type
                 #if $cond_category.category == "default":

--- a/galaxy/evaluate_sequences.xml
+++ b/galaxy/evaluate_sequences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="immuno_probs_evaulate_seqs" name="Evaluate sequences" version="0.1.18">
+<tool id="immuno_probs_evaulate" name="Evaluate sequences" version="0.1.18">
     <requirements>
         <container type="docker">penuts7644/immuno-probs</container>
     </requirements>

--- a/galaxy/generate_sequences.xml
+++ b/galaxy/generate_sequences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="immuno_probs_generate_sequences" name="Generate sequences" version="0.1.18">
+<tool id="immuno_probs_generate" name="Generate sequences" version="0.1.18">
     <requirements>
         <container type="docker">penuts7644/immuno-probs</container>
     </requirements>
@@ -38,7 +38,7 @@
                 #end if
 
                 ## number of output sequences
-                -n-gen $generate
+                -n-gen $n_gen
     </command>
 
     <inputs>
@@ -81,7 +81,7 @@
             </when>
         </conditional>
 
-        <param name="generate" type="integer" value="1" min="1" max="1000000" label="Number of sequences" help="The number of output sequences to generate from the specified IGoR model." />
+        <param name="n_gen" type="integer" value="1" min="1" max="1000000" label="Number of sequences" help="The number of output sequences to generate from the specified IGoR model." />
     </inputs>
 
     <outputs>

--- a/galaxy/generate_sequences.xml
+++ b/galaxy/generate_sequences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="immuno_probs_generate_seqs" name="Generate sequences" version="0.1.18">
+<tool id="immuno_probs_generate_sequences" name="Generate sequences" version="0.1.18">
     <requirements>
         <container type="docker">penuts7644/immuno-probs</container>
     </requirements>
@@ -13,7 +13,7 @@
             -threads \$GALAXY_SLOTS
 
             ## tool command
-            generate-seqs
+            generate
 
                 ## specify the model and possibly the type
                 #if $cond_category.category == "default":
@@ -38,7 +38,7 @@
                 #end if
 
                 ## number of output sequences
-                -generate $generate
+                -n-gen $generate
     </command>
 
     <inputs>

--- a/galaxy/locate_cdr3_anchors.xml
+++ b/galaxy/locate_cdr3_anchors.xml
@@ -13,7 +13,7 @@
             -threads \$GALAXY_SLOTS
 
             ## tool command
-            locate-cdr3-anchors
+            locate
 
                 ## reference genomic templates
                 -ref '$cond_gene.gene' '$cond_gene.file'

--- a/galaxy/locate_cdr3_anchors.xml
+++ b/galaxy/locate_cdr3_anchors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="immuno_probs_locate_cdr3_anchors" name="Locate CDR3 anchors" version="0.1.18">
+<tool id="immuno_probs_locate" name="Locate CDR3 anchors" version="0.1.18">
     <requirements>
         <container type="docker">penuts7644/immuno-probs</container>
     </requirements>

--- a/immuno_probs/cli/__main__.py
+++ b/immuno_probs/cli/__main__.py
@@ -26,8 +26,8 @@ from shutil import rmtree
 
 from immuno_probs.cli.locate_cdr3_anchors import LocateCdr3Anchors
 from immuno_probs.cli.build_igor_model import BuildIgorModel
-from immuno_probs.cli.generate_seqs import GenerateSeqs
-from immuno_probs.cli.evaluate_seqs import EvaluateSeqs
+from immuno_probs.cli.generate_sequences import GenerateSequences
+from immuno_probs.cli.evaluate_sequences import EvaluateSequences
 from immuno_probs.util.cli import dynamic_cli_options, make_colored
 from immuno_probs.util.constant import set_num_threads, set_separator, \
 set_working_dir, set_out_name, set_config_data, get_config_data
@@ -83,8 +83,8 @@ def main():
     # Add main- and suboptions to the subparser.
     lca = LocateCdr3Anchors(subparsers=subparsers)
     bim = BuildIgorModel(subparsers=subparsers)
-    ges = GenerateSeqs(subparsers=subparsers)
-    evs = EvaluateSeqs(subparsers=subparsers)
+    ges = GenerateSequences(subparsers=subparsers)
+    evs = EvaluateSequences(subparsers=subparsers)
 
     # Parse the commandline arguments and set variables.
     parsed_arguments = parser.parse_args()
@@ -122,13 +122,13 @@ def main():
         return
 
     # Execute the correct tool based on given subparser name.
-    if parsed_arguments.subparser_name == 'locate-cdr3-anchors':
+    if parsed_arguments.subparser_name == 'locate':
         lca.run(args=parsed_arguments, output_dir=output_dir)
-    elif parsed_arguments.subparser_name == 'build-igor-model':
+    elif parsed_arguments.subparser_name == 'build':
         bim.run(args=parsed_arguments, output_dir=output_dir)
-    elif parsed_arguments.subparser_name == 'generate-seqs':
+    elif parsed_arguments.subparser_name == 'generate':
         ges.run(args=parsed_arguments, output_dir=output_dir)
-    elif parsed_arguments.subparser_name == 'evaluate-seqs':
+    elif parsed_arguments.subparser_name == 'evaluate':
         evs.run(args=parsed_arguments, output_dir=output_dir)
     else:
         sys.stdout.write("No option selected, run 'immuno-probs -h' to show all options.\n")

--- a/immuno_probs/cli/build_igor_model.py
+++ b/immuno_probs/cli/build_igor_model.py
@@ -60,7 +60,7 @@ class BuildIgorModel(object):
         """
         # Create the description and options for the parser.
         description = "Create a VDJ or VJ model by executing IGoR's " \
-            "commandline tool via a python subprocess and initial model " \
+            "commandline tool via a python subprocess using default model " \
             "parameters."
         parser_options = {
             '-seqs': {
@@ -99,7 +99,7 @@ class BuildIgorModel(object):
 
         # Add the options to the parser and return the updated parser.
         parser_tool = self.subparsers.add_parser(
-            'build-igor-model', help=description, description=description)
+            'build', help=description, description=description)
         parser_tool = dynamic_cli_options(parser=parser_tool,
                                           options=parser_options)
 

--- a/immuno_probs/cli/evaluate_sequences.py
+++ b/immuno_probs/cli/evaluate_sequences.py
@@ -36,7 +36,7 @@ read_fasta_as_dataframe, write_dataframe_to_separated, preprocess_separated_file
 preprocess_reference_file, is_fasta, is_separated, copy_to_dir
 
 
-class EvaluateSeqs(object):
+class EvaluateSequences(object):
     """Commandline tool for evaluating sequences using an IGoR model.
 
     Parameters
@@ -51,7 +51,7 @@ class EvaluateSeqs(object):
 
     """
     def __init__(self, subparsers):
-        super(EvaluateSeqs, self).__init__()
+        super(EvaluateSequences, self).__init__()
         self.subparsers = subparsers
         self._add_options()
         self.col_names = {
@@ -76,7 +76,8 @@ class EvaluateSeqs(object):
         # Create the description and options for the parser.
         description = "Evaluate VDJ or VJ sequences given a custom IGoR " \
             "model (or build-in) through IGoR's commandline tool via python " \
-            "subprocess. Or evaluate CDR3 sequences through OLGA."
+            "subprocess. Or evaluate CDR3 sequences with the model by using " \
+            "OLGA."
         parser_options = {
             '-seqs': {
                 'metavar': '<fasta/separated>',
@@ -147,7 +148,7 @@ class EvaluateSeqs(object):
 
         # Add the options to the parser and return the updated parser.
         parser_tool = self.subparsers.add_parser(
-            'evaluate-seqs', help=description, description=description)
+            'evaluate', help=description, description=description)
         parser_tool = dynamic_cli_options(parser=parser_tool,
                                           options=parser_options)
 

--- a/immuno_probs/cli/generate_sequences.py
+++ b/immuno_probs/cli/generate_sequences.py
@@ -34,7 +34,7 @@ from immuno_probs.util.io import read_separated_to_dataframe, \
 write_dataframe_to_separated, preprocess_separated_file, copy_to_dir
 
 
-class GenerateSeqs(object):
+class GenerateSequences(object):
     """Commandline tool for generating sequences from and IGoR model.
 
     Parameters
@@ -49,7 +49,7 @@ class GenerateSeqs(object):
 
     """
     def __init__(self, subparsers):
-        super(GenerateSeqs, self).__init__()
+        super(GenerateSequences, self).__init__()
         self.subparsers = subparsers
         self._add_options()
         self.col_names = {
@@ -75,7 +75,8 @@ class GenerateSeqs(object):
         # Create the description and options for the parser.
         description = "Generate VDJ or VJ sequences given a custom IGoR " \
             "model (or build-in) by executing IGoR's commandline tool via " \
-            "python subprocess. Or generate CDR3 sequences by using the OLGA."
+            "python subprocess. Or generate CDR3 sequences from the model by " \
+            "using OLGA."
         parser_options = {
             '-model': {
                 'type': 'str.lower',
@@ -111,7 +112,7 @@ class GenerateSeqs(object):
                 'help': 'A IGoR parameters file followed by an IGoR ' \
                         'marginals file.'
             },
-            '-generate': {
+            '-n-gen': {
                 'type': 'int',
                 'nargs': '?',
                 'default': 1,
@@ -127,7 +128,7 @@ class GenerateSeqs(object):
 
         # Add the options to the parser and return the updated parser.
         parser_tool = self.subparsers.add_parser(
-            'generate-seqs', help=description, description=description)
+            'generate', help=description, description=description)
         parser_tool = dynamic_cli_options(parser=parser_tool,
                                           options=parser_options)
 
@@ -227,7 +228,7 @@ class GenerateSeqs(object):
                 return
 
             # Add generate command.
-            command_list.append(['generate', str(args.generate), ['noerr']])
+            command_list.append(['generate', str(args.n_gen), ['noerr']])
 
             # Execute IGoR through command line and catch error code.
             sys.stdout.write('Executing IGoR...')
@@ -352,7 +353,7 @@ class GenerateSeqs(object):
                     aa_p_col=self.col_names['AA_P_COL'],
                     v_gene_col=self.col_names['V_GENE_COL'],
                     j_gene_col=self.col_names['J_GENE_COL'])
-                cdr3_seqs_df = seq_generator.generate(num_seqs=args.generate)
+                cdr3_seqs_df = seq_generator.generate(num_seqs=args.n_gen)
                 sys.stdout.write(make_colored('success\n', 'green'))
             except (TypeError, IOError) as err:
                 sys.stdout.write(make_colored('error\n', 'red'))

--- a/immuno_probs/cli/locate_cdr3_anchors.py
+++ b/immuno_probs/cli/locate_cdr3_anchors.py
@@ -62,8 +62,8 @@ class LocateCdr3Anchors(object):
         """
         # Create the description and options for the parser.
         description = "Create an alignment for the given reference genome " \
-            "FASTA file and seach the given alignment for conserved motif " \
-            "regions."
+            "FASTA files and seach the given alignment for conserved motif " \
+            "regions. The located CDR3 anchors can be used for the other tools."
         parser_options = {
             '-ref': {
                 'metavar': ('<gene>', '<fasta>'),
@@ -87,7 +87,7 @@ class LocateCdr3Anchors(object):
 
         # Add the options to the parser and return the updated parser.
         parser_tool = self.subparsers.add_parser(
-            'locate-cdr3-anchors', help=description, description=description)
+            'locate', help=description, description=description)
         parser_tool = dynamic_cli_options(parser=parser_tool,
                                           options=parser_options)
 

--- a/immuno_probs/config/default.ini
+++ b/immuno_probs/config/default.ini
@@ -35,14 +35,14 @@ D_GENE_COL = gene_choice_d
 ; Name of the column containing the J gene choice string.
 J_GENE_COL = gene_choice_j
 
-; Parameters specific for the 'locate_cdr3_anchors' tool.
-[LOCATE_CDR3_ANCHORS]
+; Parameters specific for the 'locate' tool.
+[LOCATE]
 ; The default search motifs for the V gene.
 V_MOTIFS = TGT,TGC
 ; The default search motifs for the J gene.
 J_MOTIFS = TGG,TTC,TTT
 
-; Parameters specific for the 'evaluate_sequences' tool.
-[EVALUATE_SEQUENCES]
+; Parameters specific for the 'evaluate' tool.
+[EVALUATE]
 ; The allele value to use when allele information from the input date should not be used.
 ALLELE = 01

--- a/immuno_probs/config/default.ini
+++ b/immuno_probs/config/default.ini
@@ -42,7 +42,7 @@ V_MOTIFS = TGT,TGC
 ; The default search motifs for the J gene.
 J_MOTIFS = TGG,TTC,TTT
 
-; Parameters specific for the 'evaluate_seqs' tool.
-[EVALUATE_SEQS]
+; Parameters specific for the 'evaluate_sequences' tool.
+[EVALUATE_SEQUENCES]
 ; The allele value to use when allele information from the input date should not be used.
 ALLELE = 01


### PR DESCRIPTION
fixes #88 

In this PR:
- `locate-cdr3-anchors` tool is now renamed to `locate` throughout the package (class name remains the same).
- `build-igor-model` tool is now renamed to `build` throughout the package (class name remains the same).
- `generate-seqs` tool is now renamed to `generate` throughout the package (class name remains the same).
- `evaluate-seqs` tool is now renamed to `evaluate` throughout the package (class name remains the same).